### PR TITLE
fix(SockServer): fix TypeError on socket.error handling on python3

### DIFF
--- a/lib/candy_board_qws/__init__.py
+++ b/lib/candy_board_qws/__init__.py
@@ -354,7 +354,9 @@ class SockServer(threading.Thread):
 
             except socket.error as e:
                 if isinstance(e.args, tuple):
-                    if e[0] == errno.EPIPE:
+                    if hasattr(e, 'errno') and e.errno == errno.EPIPE:  # python3
+                        continue
+                    elif e[0] == errno.EPIPE:  # python2
                         continue
                 logger.error("Socket Error: %s" %
                                       (''.join(traceback


### PR DESCRIPTION
When a `BrokenPipeError` error occurs, python3 generates the following error when evaluating `e[0]` on [here](https://github.com/CANDY-LINE/candy-board-qws/blob/master/lib/candy_board_qws/__init__.py#L357), python2 does not.

```python
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/candy_board_qws/__init__.py", line 347, in run
    connection.sendall(packed_header)
BrokenPipeError: [Errno 32] Broken pipe
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.9/dist-packages/candy_board_qws/__init__.py", line 357, in run
    if e[0] == errno.EPIPE:
TypeError: 'BrokenPipeError' object is not subscriptable
```

This PR should work for both python2 and python3. 